### PR TITLE
Expand markdown templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,18 @@ The input can be:
 The output format can be specified as:
 - `yaml`: produces a YAML file containing a straight representation of the
   internal model.
-- `markdown`: produces a markdown report from a built-in template. The output
-  list all the packages with coverage, and all the tests, passed or failed.
-  Failure details are also included in the report.
-- `markdown-summary`: produces an alternate markdown report, tailored toward
-  build summary, focussing on package-level summary and individual failures. The
-  full report is also included in a collapsed section that can be expanded if
-  needed.
+- `md` or `markdown`: produces a markdown report from a built-in template. The
+  output list all the packages with coverage, and all the tests, passed or
+  failed. Failure details are also included in the report.
+- `mdsfd` or `markdown-summary`: produces an alternate markdown report, tailored
+  toward build summary, that includes 3 sections:
+    - A _Packages_ section containing package level summary.
+    - A _Failures_ section reporting only tests failures, and included only if
+      any test has failed.
+    - A _Full report_ section, collapsed in html preview, and expanding to
+      display the full list of tests, including all passing tests.
+- `mds` or `mdsf`: variants of the `mdsfd` template containing either just
+  summary or summary and failures, no details.
 - a custom template filename (see [Using Custom
 Template](#using-custom-template))
 

--- a/pkg/cmd/report/cmd.go
+++ b/pkg/cmd/report/cmd.go
@@ -101,11 +101,13 @@ func (cmd *Cmd) saveOutput(output string, results *model.Results) error {
 		"HeaderShift": cmd.ShiftHeader,
 	}
 
-	if builtin, ok := template.Builtin[parts[0]]; ok {
+	if srcs, ok := template.Builtin[parts[0]]; ok {
 		tmpl = template.New("report", values)
-		_, err := tmpl.Parse(builtin)
-		if err != nil {
-			return err
+		for _, src := range srcs {
+			_, err := tmpl.Parse(src)
+			if err != nil {
+				return err
+			}
 		}
 	} else {
 		tmpl = template.New(parts[0], values)

--- a/pkg/template/markdown.go
+++ b/pkg/template/markdown.go
@@ -1,27 +1,54 @@
 package template
 
-var Builtin = map[string]string{
-	"md":               MarkdownTemplate,
-	"markdown":         MarkdownTemplate,
-	"markdown-summary": MarkdownSummaryTemplate,
+var Builtin = map[string][]string{
+	"md":       {MarkdownShared, MarkdownTemplate},
+	"markdown": {MarkdownShared, MarkdownTemplate},
+
+	"mds":              {MarkdownShared, MarkdownSTemplate},
+	"mdsf":             {MarkdownShared, MarkdownSFTemplate},
+	"mdsfd":            {MarkdownShared, MarkdownSFDTemplate},
+	"markdown-summary": {MarkdownShared, MarkdownSFDTemplate},
 }
 
-// MarkdownTemplate contains the definition for the built-in template used to
-// generate Markdown report
-var MarkdownTemplate = `
-{{- if ne Title "" -}}
-{{ header 1 }} {{ Title }}
-{{- end }}
-{{- range . -}}
-{{- template "package" . -}}
-{{- end }}
+// MarkdownShared contains common built-in definitions shared by one or more
+// markdown output templates.
+var MarkdownShared = `
+{{- define "package-summary" -}}
+{{-   if gt (len .Tests) 0 }}
+| {{ render "package-outcome" . }} {{ .Name }} | {{ .Passed }} | {{ .Failed }} | {{ .Coverage }}% |
+{{-    end -}}
+{{- end -}}
+
+{{- define "package-outcome" }}
+{{-   if gt .Failed 0 -}}❌{{- else -}}✅{{- end -}}
+{{- end -}}
+
+{{/* -------------------------------------------------------------------- */}}
+
+{{- define "package-failures" }}
+{{ header 3 }} {{ .Name }}
+{{    range .Tests -}}
+{{-     if .Failure -}}
+{{-       render "test-failure" . -}}
+{{-     end -}}
+{{-   end }}
+{{- end -}}
+
+{{- define "test-failure" }}
+- {{  render "outcome" . }} {{ .Name }}
+{{-   render "output" . | indent 2 -}}
+{{-   range .Tests -}}
+{{-     if .Failure -}}
+{{-       render "test-failure" . | indent 2 -}}
+{{-     end -}}
+{{-   end -}}
+{{- end -}}
 
 {{/* -------------------------------------------------------------------- */}}
 
 {{- define "package" -}}
 {{-   if gt (len .Tests) 0 }}
-
-{{ header 2 }} {{ .Name }}
+{{ header 3 }} {{ .Name }}
 
 Coverage: {{ .Coverage }}%
 {{      range .Tests -}}
@@ -53,21 +80,25 @@ Coverage: {{ .Coverage }}%
 {{- end -}}
 `
 
-// {{- "" -}}
-
-// MarkdownSummaryTemplate contains the definition for the built-in template
-// used to generate an alternate Markdown report focussed on summary and
-// surfacing failures
-var MarkdownSummaryTemplate = `
-{{- $any_failure := false -}}
-{{- range . -}}
-{{-   if gt .Failed 0 -}}{{- $any_failure = true -}}{{- end -}}
-{{- end -}}
-
+// MarkdownTemplate contains the definition for the built-in template used to
+// generate Markdown report
+var MarkdownTemplate = `
 {{- if ne Title "" -}}
 {{ header 1 }} {{ Title }}
 {{- end }}
+{{- range . -}}
+{{- template "package" . -}}
+{{- end }}
+`
 
+// MarkdownSFDTemplate contains the definition for the built-in template
+// used to generate an alternate Markdown report focussed on summary and
+// surfacing failures
+var MarkdownSFDTemplate = `
+{{- if ne Title "" -}}
+{{ header 1 }} {{ Title }}
+
+{{ end -}}
 {{ header 2 }} Packages
 
 | Package | Passed | Failed | Coverage |
@@ -76,6 +107,10 @@ var MarkdownSummaryTemplate = `
 {{-   template "package-summary" . -}}
 {{- end -}}
 
+{{- $any_failure := false -}}
+{{- range . -}}
+{{-   if gt .Failed 0 -}}{{- $any_failure = true -}}{{- end -}}
+{{- end -}}
 {{- if $any_failure }}
 
 {{ header 2 }} Failures
@@ -86,84 +121,61 @@ var MarkdownSummaryTemplate = `
 {{- end -}}
 {{- end }}
 
-{{ header 2 }} Details
+{{ header 2 }} Full report
 
 <details>
-<summary>Full report</summary>
+<summary>Expand</summary>
 
 {{ range . -}}
 {{- template "package" . -}}
 {{- end -}}
 
 </details>
+`
 
-{{/* -------------------------------------------------------------------- */}}
+// MarkdownSTemplate follows the same format as the SFD (summary, failures,
+// details) template, but includes only the package summary.
+var MarkdownSTemplate = `
+{{- if ne Title "" -}}
+{{ header 1 }} {{ Title }}
 
-{{- define "package-summary" -}}
-{{-   if gt (len .Tests) 0 }}
-| {{ render "package-outcome" . }} {{ .Name }} | {{ .Passed }} | {{ .Failed }} | {{ .Coverage }}% |
-{{-    end -}}
+{{ end -}}
+{{ header 2 }} Packages
+
+| Package | Passed | Failed | Coverage |
+|-|-|-|-|
+{{- range . -}}
+{{-   template "package-summary" . -}}
+{{- end }}
+`
+
+// MarkdownSFTemplate follows the same format as the SFD (summary, failures,
+// details) template, but includes only the package summary and test failures if
+// any.
+var MarkdownSFTemplate = `
+{{- if ne Title "" -}}
+{{ header 1 }} {{ Title }}
+
+{{ end -}}
+{{ header 2 }} Packages
+
+| Package | Passed | Failed | Coverage |
+|-|-|-|-|
+{{- range . -}}
+{{-   template "package-summary" . -}}
 {{- end -}}
 
-{{- define "package-outcome" }}
-{{-   if gt .Failed 0 -}}❌{{- else -}}✅{{- end -}}
+{{- $any_failure := false -}}
+{{- range . -}}
+{{-   if gt .Failed 0 -}}{{- $any_failure = true -}}{{- end -}}
 {{- end -}}
+{{- if $any_failure }}
 
-
-{{/* -------------------------------------------------------------------- */}}
-
-{{- define "package-failures" }}
-{{ header 3 }} {{ .Name }}
-{{    range .Tests -}}
-{{-     if .Failure -}}
-{{-       render "test-failure" . -}}
-{{-     end -}}
-{{-   end }}
-{{- end -}}
-
-{{- define "test-failure" }}
-- {{  render "outcome" . }} {{ .Name }}
-{{-   render "output" . | indent 2 -}}
-{{-   range .Tests -}}
-{{-     if .Failure -}}
-{{-       render "test-failure" . | indent 2 -}}
-{{-     end -}}
+{{ header 2 }} Failures
+{{ range . -}}
+{{-   if gt .Failed 0 -}}
+{{-     template "package-failures" . -}}
 {{-   end -}}
 {{- end -}}
-
-
-{{/* -------------------------------------------------------------------- */}}
-
-{{- define "package" -}}
-{{-   if gt (len .Tests) 0 }}
-{{ header 3 }} {{ .Name }}
-
-Coverage: {{ .Coverage }}%
-{{      range .Tests -}}
-{{-       render "test" . -}}
-{{-     end }}
-{{    end -}}
-{{- end -}}
-
-{{- define "test" }}
-- {{ render "outcome" . }} {{ .Name }}
-{{-   render "output" . | indent 2 -}}
-{{-   range .Tests -}}
-{{-     render "test" . | indent 2 -}}
-{{-   end -}}
-{{- end -}}
-
-{{- define "outcome" }}
-{{-   if .Failure -}}❌{{- else -}}✅{{- end -}}
-{{- end -}}
-
-{{- define "output" }}
-{{-   if gt (len .Output) 0 }}
-{{      codeblock -}}
-{{      range .Output }}
-{{        .  }}
-{{-     end }}
-{{      codeblock }}
-{{-   end -}}
-{{- end -}}
+{{- end }}
 `

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -42,7 +42,11 @@ func indent(spaces int, v string) string {
 
 func header(offset int) func(level int) string {
 	return func(level int) string {
-		return strings.Repeat("#", level+offset)
+		var n = level + offset
+		if n < 1 {
+			n = 1
+		}
+		return strings.Repeat("#", n)
 	}
 }
 


### PR DESCRIPTION
- Define built-in templates as a collection of template fragments, and factor out common definitions
- Add more template to render only package summary or summary and failures
- Update README with new template names and details
- Add better support for negative values of `--md-shift-headers`, clamping up to h1